### PR TITLE
chore: migrate to grpc.NewClient, add CI linting

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,12 +17,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
-        go-version: "1.25"
+        go-version-file: go.mod
 
     - name: Build
       run: make build
@@ -30,12 +30,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
-        go-version: "1.25"
+        go-version-file: go.mod
 
     - name: Test
       run: make test
@@ -43,15 +43,15 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
-        go-version: "1.25"
+        go-version-file: go.mod
 
     - name: Lint
-      uses: golangci/golangci-lint-action@v9
+      uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
       with:
         version: v2.8
         args: --timeout 5m

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,33 @@ jobs:
         go-version: "1.25"
 
     - name: Build
-      run: go build -v ./...
+      run: make build
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: "1.25"
 
     - name: Test
-      run: go test -v ./...
+      run: make test
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: "1.25"
+
+    - name: Lint
+      uses: golangci/golangci-lint-action@v9
+      with:
+        version: v2.8
+        args: --timeout 5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,28 @@
+version: "2"
+linters:
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - funlen
+          - goconst
+          - errcheck
+          - ineffassign
+          - staticcheck
+        path: (.+)_test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ doc:
 	gomarkdoc --output '{{.Dir}}/README.md' ./...
 
 lint:
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 	golangci-lint run
 
 bench:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ build:
 	go build ./...
 
 test:
-	go test ./... -race
+	go test -race ./...
 
 doc:
 	go install github.com/princjef/gomarkdoc/cmd/gomarkdoc
@@ -13,4 +13,4 @@ lint:
 	golangci-lint run
 
 bench:
-	go test -bench=. -benchmem ./...
+	go test -run=^$ -bench=. -benchmem ./...

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
-.PHONY: build test doc
+.PHONY: build test doc lint bench
 build:
 	go build ./...
 
 test:
-	go test ./...
+	go test ./... -race
 
 doc:
 	go install github.com/princjef/gomarkdoc/cmd/gomarkdoc
 	gomarkdoc --output '{{.Dir}}/README.md' ./...
+
+lint:
+	golangci-lint run
+
+bench:
+	go test -bench=. -benchmem ./...

--- a/pool.go
+++ b/pool.go
@@ -77,13 +77,13 @@ func New(conns []*grpc.ClientConn) ConnPool {
 }
 
 // DialContext creates a new ConnPool with num connections to target.
-func DialContext(ctx context.Context, target string, num uint, opts ...grpc.DialOption) (ConnPool, error) {
+func DialContext(_ context.Context, target string, num uint, opts ...grpc.DialOption) (ConnPool, error) {
 	if num == 0 {
 		return nil, errors.New("grpcpool: num must be greater than 0")
 	}
 	conns := make([]*grpc.ClientConn, num)
 	for i := range conns {
-		conn, err := grpc.DialContext(ctx, target, opts...)
+		conn, err := grpc.NewClient(target, opts...)
 		if err != nil {
 			return nil, err
 		}

--- a/pool.go
+++ b/pool.go
@@ -77,6 +77,9 @@ func New(conns []*grpc.ClientConn) ConnPool {
 }
 
 // DialContext creates a new ConnPool with num connections to target.
+//
+// Note: The ctx parameter is retained for backward compatibility but is not
+// used. Cancellation and deadlines in ctx do not affect connection creation.
 func DialContext(_ context.Context, target string, num uint, opts ...grpc.DialOption) (ConnPool, error) {
 	if num == 0 {
 		return nil, errors.New("grpcpool: num must be greater than 0")
@@ -85,6 +88,12 @@ func DialContext(_ context.Context, target string, num uint, opts ...grpc.DialOp
 	for i := range conns {
 		conn, err := grpc.NewClient(target, opts...)
 		if err != nil {
+			// Close any connections created before the failure
+			for _, c := range conns[:i] {
+				if c != nil {
+					c.Close()
+				}
+			}
 			return nil, err
 		}
 		conns[i] = conn

--- a/pool_test.go
+++ b/pool_test.go
@@ -1,6 +1,7 @@
 package grpcpool
 
 import (
+	"context"
 	"net"
 	"testing"
 
@@ -64,4 +65,27 @@ func mockServer(t *testing.T) (*grpc.Server, net.Listener) {
 	go s.Serve(l)
 
 	return s, l
+}
+
+func TestDialContext_ZeroNum(t *testing.T) {
+	_, err := DialContext(context.Background(), "localhost:0", 0)
+	if err == nil {
+		t.Fatal("expected error for num=0")
+	}
+}
+
+func TestDialContext_Success(t *testing.T) {
+	_, l := mockServer(t)
+	defer l.Close()
+
+	pool, err := DialContext(context.Background(), l.Addr().String(), 3,
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("DialContext: %v", err)
+	}
+	defer pool.Close()
+
+	if pool.Num() != 3 {
+		t.Errorf("pool.Num() = %d; want 3", pool.Num())
+	}
 }


### PR DESCRIPTION
## Summary
- Replace deprecated `grpc.DialContext` with `grpc.NewClient`
- Add golangci-lint config and CI lint job
- Add `-race` flag to test target
- Standardize CI with separate build/test/lint jobs

## Test plan
- [x] `make build` passes
- [x] `make test` passes (with -race)
- [x] `make lint` passes with 0 issues