### PR TITLE
feat: add SupportPackageIsVersion1 compile-time version sentinel

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -9,6 +9,10 @@ import (
 	"google.golang.org/grpc"
 )
 
+// SupportPackageIsVersion1 is a compile-time assertion constant.
+// Downstream packages reference this to enforce version compatibility.
+const SupportPackageIsVersion1 = true
+
 // based on https://github.com/googleapis/google-api-go-client/blob/v0.115.0/transport/grpc/pool.go
 
 // ConnPool is a pool of grpc.ClientConns.


### PR DESCRIPTION
## Summary
- Add `SupportPackageIsVersion1` constant following the gRPC `SupportPackageIsVersion` pattern
- Downstream packages reference this constant to enforce version compatibility at compile time
- When a breaking change is made, export a new version and remove the old one to force coordinated updates

## Test plan
- [x] `go build ./...` passes